### PR TITLE
Solved IllegalThreadStateException

### DIFF
--- a/app/src/main/java/com/self/androidarchdemos/MainActivityViewModel.java
+++ b/app/src/main/java/com/self/androidarchdemos/MainActivityViewModel.java
@@ -15,22 +15,6 @@ public class MainActivityViewModel extends ViewModel {
     public MainActivityViewModel(){
         isCounterInProgress = false;
         counterValue = new MutableLiveData<>();
-
-        counterThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                while (isCounterInProgress) {
-                    try {
-                        Thread.sleep(1000);
-                        count++;
-                        counterValue.postValue(count);
-                    }catch (InterruptedException e){
-                        e.printStackTrace();
-                    }
-
-                }
-            }
-        });
     }
 
     public LiveData<Integer> getCounterValue(){
@@ -40,6 +24,22 @@ public class MainActivityViewModel extends ViewModel {
     public void startCounter(){
         if(!isCounterInProgress){
             isCounterInProgress = true;
+
+            counterThread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    while (isCounterInProgress) {
+                        try {
+                            Thread.sleep(1000);
+                            count++;
+                            counterValue.postValue(count);
+                        }catch (InterruptedException e){
+                            e.printStackTrace();
+                        }
+
+                    }
+                }
+            });
             counterThread.start();
         }
     }


### PR DESCRIPTION
### Shifted code-block from constructor to startCount
When we click on start after clicking on stop, the app crashes throwing the following error:

`E/ndroidarchdemo: [qarth_debug:] get PatchStore::createDisableExceptionQarthFile method fail. E/AndroidRuntime: FATAL EXCEPTION: main Process: com.self.androidarchdemos, PID: 12860 java.lang.IllegalThreadStateException at java.lang.Thread.start(Thread.java:744) at com.self.androidarchdemos.MainActivityViewModel.startCounter(MainActivityViewModel.java:43) at com.self.androidarchdemos.MainActivity$2.onClick(MainActivity.java:44) at android.view.View.performClick(View.java:6659) at android.view.View.performClickInternal(View.java:6631) at android.view.View.access$3100(View.java:790) at android.view.View$PerformClick.run(View.java:26187) at android.os.Handler.handleCallback(Handler.java:907) at android.os.Handler.dispatchMessage(Handler.java:105) at android.os.Looper.loop(Looper.java:216) at android.app.ActivityThread.main(ActivityThread.java:7625) at java.lang.reflect.Method.invoke(Native Method) at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:524) at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987) `

This error message indicates that your app has encountered a fatal exception and has crashed. The specific error is an IllegalThreadStateException which occurs when you try to start a thread that has already been started.
Looking at the stack trace, the exception is being thrown in the startCounter() method of MainActivityViewModel class at line 38. It seems that you are attempting to start a thread more than once, which is not allowed.
To solve this error, you should check if the thread is already running before starting it again. One approach is to use a boolean flag to track the state of the thread. For example, you could define a boolean variable isCounterRunning in your MainActivityViewModel class and set it to true when the thread is started and false when it is stopped.
Then, before starting the thread, you should check if isCounterRunning is false. If it is true, it means the thread is already running and you should not start it again.
### To solve the error, I shifted the code block from the constructor to the startCounter() method.

